### PR TITLE
Fewer headings

### DIFF
--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -251,12 +251,10 @@ DATAGRAM frames are delivered to the remote WebTransport endpoint reliably,
 however this does not require that the receiving implementation deliver that
 data to the application in a reliable manner.
 
-# WebTransport Protocol Details
-
 ## WebTransport Stream States
 
 WebTransport streams have states that mirror the states of QUIC streams
-(Section 3 of {{!RFC9000}}) as closely as possible to aid in ease of
+({{Section 3 of !RFC9000}}) as closely as possible to aid in ease of
 implementation.
 
 Because WebTransport does not provide an acknowledgement mechanism for


### PR DESCRIPTION
The features and protocol details are really different concepts (one
relates to what the protocol does, the other to the implications of
that), but the current structure is poor.  I was taught that you never
leave a section heading empty (S5 currently) and that you never have
just a single subsection (S4.1 and S5.1).  Expanding the scope of the
section is an elegant solution.