### PR TITLE
Padding field in WT_PADDING

### DIFF
--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -306,12 +306,12 @@ used to provide protection against traffic analysis or for other reasons.
 WT_PADDING Frame {
   Type (i) = 0x00,
   Length (i),
+  Padding (..),
 }
 ~~~
 {: #fig-wt_padding title="WT_PADDING Frame Format"}
 
-The padding extends to the end of the WT_PADDING frame and that many bytes can
-be discarded by the recipient.
+The Padding field MUST be set to an all-zero sequence of bytes of any length.
 
 ## WT_RESET_STREAM Frames
 

--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -311,7 +311,9 @@ WT_PADDING Frame {
 ~~~
 {: #fig-wt_padding title="WT_PADDING Frame Format"}
 
-The Padding field MUST be set to an all-zero sequence of bytes of any length.
+The Padding field MUST be set to an all-zero sequence of bytes of any length as
+specified by the Length field.
+<!-- TODO validation and error handling -->
 
 ## WT_RESET_STREAM Frames
 


### PR DESCRIPTION
The frame format depends on having a definition.  I've also made a
requirement for this to be zero values.  Do we need to say that
recipients MUST NOT validate this or that they MAY opt to avoid
validation.