### PR TITLE
Fix reference to WT-Available-Protocols and WT-Protocol

### DIFF
--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -223,7 +223,7 @@ include a single choice from the client's list in that field. Servers MAY reject
 the request if the client did not include a suitable protocol.
 
 Both `WT-Available-Protocols` and `WT-Protocol` are defined in
-{{Section 3.4 of WEBTRANSPORT-H3}}.
+{{Section 3.3 of WEBTRANSPORT-H3}}.
 
 ## Session Termination and Error Handling {#errors}
 


### PR DESCRIPTION
The header fields are defined in Section 3.3: https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3-15#name-application-protocol-negoti