### PR TITLE
Match H3: Specify receiver behavior for invalid Maximum Streams values

### DIFF
--- a/draft-ietf-webtrans-http2.md
+++ b/draft-ietf-webtrans-http2.md
@@ -835,7 +835,9 @@ WT_MAX_STREAMS capsules contain the following field:
    : A count of the cumulative number of streams of the corresponding type that
      can be opened over the lifetime of the connection. This value cannot
      exceed 2<sup>60</sup>, as it is not possible to encode stream IDs larger
-     than 2<sup>62</sup>-1.
+     than 2<sup>62</sup>-1.  Recipients of a capsule with a Maximum Streams
+     value larger than this limit MUST close the WebTransport session with a
+     WEBTRANSPORT_FLOW_CONTROL_ERROR session error.
 
 An endpoint MUST NOT open more streams than permitted by the current stream
 limit set by its peer.  For instance, a server that receives a unidirectional
@@ -983,6 +985,9 @@ WT_STREAMS_BLOCKED capsules contain the following field:
    : A variable-length integer indicating the maximum number of streams allowed
      at the time the capsule was sent. This value cannot exceed 2<sup>60</sup>,
      as it is not possible to encode stream IDs larger than 2<sup>62</sup>-1.
+     Recipients of a capsule with a Maximum Streams value larger than this
+     limit MUST close the WebTransport session with a
+     WEBTRANSPORT_FLOW_CONTROL_ERROR session error.
 
 The WT_STREAMS_BLOCKED capsule defines special intermediary handling, as
 described in {{Section 3.2 of HTTP-DATAGRAM}}.  Intermediaries MUST consume


### PR DESCRIPTION
Add WEBTRANSPORT_FLOW_CONTROL_ERROR receiver behavior for WT_MAX_STREAMS and WT_STREAMS_BLOCKED Maximum Streams values exceeding 2^60, matching the H3 text and the rest of the H2 flow-control section.

Fixes #267